### PR TITLE
Implement the command that allows users to view other user's timezone

### DIFF
--- a/cogs/logging/logging.py
+++ b/cogs/logging/logging.py
@@ -179,6 +179,28 @@ class Logging(commands.Cog):
         await Timezones.insert(update_on_conflict=Timezones.timezone, user_id=ctx.author.id, timezone=timezone.key)
         await ctx.tick()
 
+    @timezone.command(name='get')
+    async def timezone_get(self, ctx, *, user: discord.Member):
+        """Get a member's timezone."""
+        timezone = await Timezones.fetchrow(user_id=user.id)
+        
+        if timezone is None:
+            embed = discord.Embed(
+                title = "Error",
+                description = f"User {user.name} doens't have a saved timezone.",
+                colour = discord.Colour.red()
+            )
+            return await ctx.send(embed = embed)
+        
+        embed = discord.Embed(
+            title = "Timezone info",
+            description = f"User {user.name}'s timezone is {timezone['timezone']}",
+            colour = discord.Colour.blue()
+        )
+      
+        await ctx.send(embed = embed)
+        await ctx.tick()
+
     @timezone.command(name='delete', aliases=['unset'])
     async def timezone_delete(self, ctx):
         """Removes your timezone from the database"""


### PR DESCRIPTION
Hello again, Josh B. Ijiji.

In this pull request I would like to fix this issue with your Bot (stylized as BotBot) where it doesn't have a command that allows us, the users of your Bot (stylized as BotBot) to view the timezones of your Bot's (stylized as BotBot) members (the formal audience that interacts with your bot). This is a task of great scale that I formally requested you to implement exactly 5 seconds ago, however it occurred to me that I could fix it myself, and so I did. Please take great care while reviewing this tremendously massive GitHub Pull Request, there's a great amount of new logic added, that requires immaculate internal Quality Assurance processes and masterful code review.

This pull request fixes #2.

Best regards, Ilya C. Onecat.